### PR TITLE
fix: stop serving the stored prerelease feed to stable appcast clients

### DIFF
--- a/app/api/v1/appcast/[...path]/route.ts
+++ b/app/api/v1/appcast/[...path]/route.ts
@@ -85,9 +85,11 @@ function constructAppcastUrl(baseUrl: string, appcastPath: string): string {
   // Check if the base URL already ends with the appcast filename
   // This handles cases where the full appcast URL is stored in the database
   if (cleanBaseUrl.endsWith(".xml")) {
-    // If the base URL already includes the XML file, use it as-is
-    // Unless the appcast path is different from the default
-    if (appcastPath === "appcast.xml" || cleanBaseUrl.endsWith(`/${appcastPath}`)) {
+    // If the stored URL already points at the requested file, use it as-is.
+    // Key this only on whether the stored filename matches the requested one;
+    // matching on the default "appcast.xml" name regardless of the stored file
+    // served stable clients a stored prerelease feed.
+    if (cleanBaseUrl.endsWith(`/${appcastPath}`) || cleanBaseUrl === appcastPath) {
       return cleanBaseUrl.startsWith("http://") || cleanBaseUrl.startsWith("https://")
         ? cleanBaseUrl
         : `https://${cleanBaseUrl}`;

--- a/app/api/v1/appcast/[...path]/route.ts
+++ b/app/api/v1/appcast/[...path]/route.ts
@@ -78,29 +78,60 @@ function getIpFromRequest(request: NextRequest): string {
   return "unknown_ip";
 }
 
+function withProtocol(url: string): string {
+  return url.startsWith("http://") || url.startsWith("https://") ? url : `https://${url}`;
+}
+
+function appcastFileName(path: string): string {
+  return path.split("/").pop() || path;
+}
+
+function splitUrlSuffix(url: string): { path: string; suffix: string } {
+  const suffixIndex = url.search(/[?#]/);
+  if (suffixIndex === -1) {
+    return { path: url, suffix: "" };
+  }
+
+  return {
+    path: url.slice(0, suffixIndex),
+    suffix: url.slice(suffixIndex),
+  };
+}
+
+function isKnownUnstableAppcastFile(fileName: string): boolean {
+  return fileName === "appcast-beta.xml" || fileName === "appcast-prerelease.xml";
+}
+
 function constructAppcastUrl(baseUrl: string, appcastPath: string): string {
-  // Remove trailing slash from base URL if present
-  const cleanBaseUrl = baseUrl.replace(/\/$/, "");
+  // Remove trailing slash from the path without mutating query strings or fragments.
+  const baseUrlParts = splitUrlSuffix(baseUrl);
+  const cleanBasePath = baseUrlParts.path.replace(/\/$/, "");
+  const cleanBaseUrl = `${cleanBasePath}${baseUrlParts.suffix}`;
 
   // Check if the base URL already ends with the appcast filename
   // This handles cases where the full appcast URL is stored in the database
-  if (cleanBaseUrl.endsWith(".xml")) {
-    // If the stored URL already points at the requested file, use it as-is.
-    // Key this only on whether the stored filename matches the requested one;
-    // matching on the default "appcast.xml" name regardless of the stored file
-    // served stable clients a stored prerelease feed.
-    if (cleanBaseUrl.endsWith(`/${appcastPath}`) || cleanBaseUrl === appcastPath) {
-      return cleanBaseUrl.startsWith("http://") || cleanBaseUrl.startsWith("https://")
-        ? cleanBaseUrl
-        : `https://${cleanBaseUrl}`;
+  if (cleanBasePath.endsWith(".xml")) {
+    const storedFileName = appcastFileName(cleanBasePath);
+
+    // Direct XML URLs are stable feeds by default, including custom stable
+    // filenames like releases.xml or appcast-enterprise.xml. Only the known
+    // unstable proxy basenames are rewritten for stable clients.
+    if (
+      cleanBasePath.endsWith(`/${appcastPath}`) ||
+      cleanBasePath === appcastPath ||
+      (appcastPath === "appcast.xml" && !isKnownUnstableAppcastFile(storedFileName))
+    ) {
+      return withProtocol(cleanBaseUrl);
     }
+
     // If requesting a different appcast file, replace the filename
-    const baseWithoutFile = cleanBaseUrl.slice(0, cleanBaseUrl.lastIndexOf("/"));
-    return `${baseWithoutFile}/${appcastPath}`;
+    const baseWithoutFile = cleanBasePath.slice(0, cleanBasePath.lastIndexOf("/"));
+    const replacedPath = baseWithoutFile ? `${baseWithoutFile}/${appcastPath}` : appcastPath;
+    return withProtocol(`${replacedPath}${baseUrlParts.suffix}`);
   }
 
   // Handle GitHub URLs - convert to raw.githubusercontent.com
-  const githubMatch = cleanBaseUrl.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/?$/);
+  const githubMatch = cleanBasePath.match(/^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/?$/);
   if (githubMatch) {
     const [, owner, repo] = githubMatch;
     return `https://raw.githubusercontent.com/${owner}/${repo}/refs/heads/main/${appcastPath}`;
@@ -108,12 +139,12 @@ function constructAppcastUrl(baseUrl: string, appcastPath: string): string {
 
   // For other URLs, append the appcast path
   // If baseUrl already includes protocol, use as-is
-  if (cleanBaseUrl.startsWith("http://") || cleanBaseUrl.startsWith("https://")) {
-    return `${cleanBaseUrl}/${appcastPath}`;
+  if (cleanBasePath.startsWith("http://") || cleanBasePath.startsWith("https://")) {
+    return `${cleanBasePath}/${appcastPath}${baseUrlParts.suffix}`;
   }
 
   // Otherwise, add https://
-  return `https://${cleanBaseUrl}/${appcastPath}`;
+  return `https://${cleanBasePath}/${appcastPath}${baseUrlParts.suffix}`;
 }
 
 export async function GET(

--- a/docs/APPCAST_PROXY.md
+++ b/docs/APPCAST_PROXY.md
@@ -52,6 +52,10 @@ https://stats.store/api/v1/appcast/appcast-prerelease.xml
 - Input: `https://example.com/downloads/appcast.xml`
 - Proxy uses as-is: `https://example.com/downloads/appcast.xml`
 - Smart detection prevents duplicate .xml extensions
+- Custom stable filenames are supported. If `appcast_base_url` is `https://example.com/downloads/releases.xml` and the client requests `/appcast.xml`, the proxy fetches `releases.xml`.
+- Known unstable feed filenames are `appcast-prerelease.xml` and `appcast-beta.xml`. If `appcast_base_url` accidentally points at one of these and a stable client requests `/appcast.xml`, the proxy fetches sibling `appcast.xml` instead of serving the unstable feed.
+- Other custom stable filenames remain exact URLs, including names like `appcast-enterprise.xml`.
+- Query strings and fragments on direct `.xml` URLs are preserved when the proxy uses the URL as-is or replaces the filename.
 
 ### Domain only
 
@@ -63,6 +67,8 @@ https://stats.store/api/v1/appcast/appcast-prerelease.xml
 The proxy intelligently handles cases where:
 
 - The base URL already includes the `.xml` file - it won't add it again
+- A direct stable `.xml` URL has a custom filename - default `/appcast.xml` clients still receive that configured URL
+- A stored known unstable filename would otherwise be served to a stable client - default `/appcast.xml` requests fetch sibling `appcast.xml`
 - You're requesting a different appcast file (e.g., `appcast-beta.xml`) - it will replace the filename
 - The base URL is a folder - it will append the requested appcast filename
 

--- a/scripts/10-add-appcast-url-to-apps.sql
+++ b/scripts/10-add-appcast-url-to-apps.sql
@@ -3,4 +3,4 @@ ALTER TABLE public.apps
 ADD COLUMN appcast_base_url TEXT;
 
 -- Add comment to explain the field
-COMMENT ON COLUMN public.apps.appcast_base_url IS 'Base URL for the appcast. For GitHub repos, use the repo URL (e.g., https://github.com/owner/repo). For other domains, use the base domain (e.g., https://mydomain.com)';
+COMMENT ON COLUMN public.apps.appcast_base_url IS 'Canonical stable appcast base URL. For GitHub repos, use the repo URL (e.g., https://github.com/owner/repo). For other domains, use the base domain or a direct stable XML feed (custom stable filenames supported; appcast-prerelease.xml and appcast-beta.xml are known unstable feed filenames).';

--- a/tests/api/appcast.test.ts
+++ b/tests/api/appcast.test.ts
@@ -212,6 +212,50 @@ describe("/api/v1/appcast/[...path]", () => {
     );
   });
 
+  it("should swap the filename when the stored URL is a non-default .xml feed", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      headers: new Headers({
+        "Content-Type": "application/xml",
+      }),
+      ok: true,
+      text: async () => "<xml></xml>",
+    } as Response);
+
+    // Stored URL points at the prerelease feed; a stable client requests appcast.xml.
+    const { createSupabaseServerClient } = await import("@/lib/supabase/server");
+    vi.mocked(createSupabaseServerClient).mockReturnValueOnce({
+      from: vi.fn(() => ({
+        insert: vi.fn(() => Promise.resolve({ error: null })),
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn(() =>
+              Promise.resolve({
+                data: {
+                  id: "test-app-id",
+                  appcast_base_url: "https://example.com/updates/appcast-prerelease.xml",
+                },
+                error: null,
+              }),
+            ),
+          })),
+        })),
+      })),
+    } as unknown as SupabaseClient);
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/v1/appcast/appcast.xml?bundleIdentifier=com.example.app",
+      { method: "GET" },
+    );
+
+    await GET(request, { params: Promise.resolve({ path: ["appcast.xml"] }) });
+
+    // The stable client must get appcast.xml, not the stored prerelease feed.
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com/updates/appcast.xml",
+      expect.any(Object),
+    );
+  });
+
   it("should parse app identification from User-Agent when no params provided", async () => {
     const mockAppcastXML = '<?xml version="1.0"?><rss></rss>';
 

--- a/tests/api/appcast.test.ts
+++ b/tests/api/appcast.test.ts
@@ -1,10 +1,14 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "@/app/api/v1/appcast/[...path]/route";
 
 // Mock fetch
-global.fetch = vi.fn();
+const realFetch = global.fetch;
+const mockFetch = vi.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
 
 // Mock Supabase
 vi.mock("@/lib/supabase/server", () => ({
@@ -30,8 +34,70 @@ vi.mock("@/lib/supabase/server", () => ({
 
 describe("/api/v1/appcast/[...path]", () => {
   beforeEach(() => {
+    global.fetch = mockFetch as unknown as typeof fetch;
     vi.clearAllMocks();
   });
+
+  async function mockAppcastBaseUrl(appcastBaseUrl: string) {
+    const { createSupabaseServerClient } = await import("@/lib/supabase/server");
+    vi.mocked(createSupabaseServerClient).mockReturnValueOnce({
+      from: vi.fn(() => ({
+        insert: vi.fn(() => Promise.resolve({ error: null })),
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn(() =>
+              Promise.resolve({
+                data: {
+                  appcast_base_url: appcastBaseUrl,
+                  id: "test-app-id",
+                },
+                error: null,
+              }),
+            ),
+          })),
+        })),
+      })),
+    } as unknown as SupabaseClient);
+  }
+
+  async function startLocalAppcastServer() {
+    const requests: string[] = [];
+    const server = createServer((request, response) => {
+      requests.push(request.url || "");
+      response.setHeader("Content-Type", "application/xml");
+
+      if (request.url === "/updates/appcast.xml") {
+        response.end("<stable></stable>");
+        return;
+      }
+
+      if (request.url === "/updates/appcast-prerelease.xml") {
+        response.end("<prerelease></prerelease>");
+        return;
+      }
+
+      response.statusCode = 404;
+      response.end("<missing></missing>");
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address() as AddressInfo;
+
+    return {
+      close: () =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => {
+            if (error) {
+              reject(error);
+              return;
+            }
+            resolve();
+          });
+        }),
+      origin: `http://127.0.0.1:${address.port}`,
+      requests,
+    };
+  }
 
   it("should proxy appcast and capture telemetry", async () => {
     const mockAppcastXML = '<?xml version="1.0"?><rss><channel><item></item></channel></rss>';
@@ -168,6 +234,128 @@ describe("/api/v1/appcast/[...path]", () => {
     );
   });
 
+  it("should preserve custom direct stable XML filenames for default clients", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      headers: new Headers({
+        "Content-Type": "application/xml",
+      }),
+      ok: true,
+      text: async () => "<xml></xml>",
+    } as Response);
+
+    await mockAppcastBaseUrl("https://example.com/downloads/releases.xml");
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/v1/appcast/appcast.xml?bundleIdentifier=com.example.app",
+      { method: "GET" },
+    );
+
+    await GET(request, { params: Promise.resolve({ path: ["appcast.xml"] }) });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com/downloads/releases.xml",
+      expect.any(Object),
+    );
+  });
+
+  it("should preserve unrecognized appcast-prefixed XML filenames for default clients", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      headers: new Headers({
+        "Content-Type": "application/xml",
+      }),
+      ok: true,
+      text: async () => "<xml></xml>",
+    } as Response);
+
+    await mockAppcastBaseUrl("https://example.com/downloads/appcast-enterprise.xml");
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/v1/appcast/appcast.xml?bundleIdentifier=com.example.app",
+      { method: "GET" },
+    );
+
+    await GET(request, { params: Promise.resolve({ path: ["appcast.xml"] }) });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com/downloads/appcast-enterprise.xml",
+      expect.any(Object),
+    );
+  });
+
+  it("should preserve custom direct stable XML URLs with query parameters", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      headers: new Headers({
+        "Content-Type": "application/xml",
+      }),
+      ok: true,
+      text: async () => "<xml></xml>",
+    } as Response);
+
+    await mockAppcastBaseUrl("https://example.com/downloads/appcast-enterprise.xml?token=abc");
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/v1/appcast/appcast.xml?bundleIdentifier=com.example.app",
+      { method: "GET" },
+    );
+
+    await GET(request, { params: Promise.resolve({ path: ["appcast.xml"] }) });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com/downloads/appcast-enterprise.xml?token=abc",
+      expect.any(Object),
+    );
+  });
+
+  it("should preserve unrecognized mixed-case appcast XML filenames for default clients", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      headers: new Headers({
+        "Content-Type": "application/xml",
+      }),
+      ok: true,
+      text: async () => "<xml></xml>",
+    } as Response);
+
+    await mockAppcastBaseUrl("https://example.com/downloads/Appcast-Beta.xml");
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/v1/appcast/appcast.xml?bundleIdentifier=com.example.app",
+      { method: "GET" },
+    );
+
+    await GET(request, { params: Promise.resolve({ path: ["appcast.xml"] }) });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com/downloads/Appcast-Beta.xml",
+      expect.any(Object),
+    );
+  });
+
+  it("should preserve trailing slashes inside direct XML query parameters", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      headers: new Headers({
+        "Content-Type": "application/xml",
+      }),
+      ok: true,
+      text: async () => "<xml></xml>",
+    } as Response);
+
+    await mockAppcastBaseUrl(
+      "https://example.com/downloads/releases.xml?redirect=https://cdn.example/",
+    );
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/v1/appcast/appcast.xml?bundleIdentifier=com.example.app",
+      { method: "GET" },
+    );
+
+    await GET(request, { params: Promise.resolve({ path: ["appcast.xml"] }) });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com/downloads/releases.xml?redirect=https://cdn.example/",
+      expect.any(Object),
+    );
+  });
+
   it("should replace XML filename when requesting different appcast file", async () => {
     vi.mocked(global.fetch).mockResolvedValueOnce({
       headers: new Headers({
@@ -254,6 +442,148 @@ describe("/api/v1/appcast/[...path]", () => {
       "https://example.com/updates/appcast.xml",
       expect.any(Object),
     );
+  });
+
+  it("should swap a known stored beta feed filename for stable clients", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      headers: new Headers({
+        "Content-Type": "application/xml",
+      }),
+      ok: true,
+      text: async () => "<xml></xml>",
+    } as Response);
+
+    await mockAppcastBaseUrl("https://example.com/updates/appcast-beta.xml");
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/v1/appcast/appcast.xml?bundleIdentifier=com.example.app",
+      { method: "GET" },
+    );
+
+    await GET(request, { params: Promise.resolve({ path: ["appcast.xml"] }) });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com/updates/appcast.xml",
+      expect.any(Object),
+    );
+  });
+
+  it("should swap a known stored beta feed filename with query parameters for stable clients", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      headers: new Headers({
+        "Content-Type": "application/xml",
+      }),
+      ok: true,
+      text: async () => "<xml></xml>",
+    } as Response);
+
+    await mockAppcastBaseUrl("https://example.com/updates/appcast-beta.xml?token=abc");
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/v1/appcast/appcast.xml?bundleIdentifier=com.example.app",
+      { method: "GET" },
+    );
+
+    await GET(request, { params: Promise.resolve({ path: ["appcast.xml"] }) });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com/updates/appcast.xml?token=abc",
+      expect.any(Object),
+    );
+  });
+
+  it("should preserve trailing slashes inside fragments when replacing known unstable filenames", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      headers: new Headers({
+        "Content-Type": "application/xml",
+      }),
+      ok: true,
+      text: async () => "<xml></xml>",
+    } as Response);
+
+    await mockAppcastBaseUrl("https://example.com/updates/appcast-beta.xml#stable/");
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/v1/appcast/appcast.xml?bundleIdentifier=com.example.app",
+      { method: "GET" },
+    );
+
+    await GET(request, { params: Promise.resolve({ path: ["appcast.xml"] }) });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com/updates/appcast.xml#stable/",
+      expect.any(Object),
+    );
+  });
+
+  it("should replace a stored stable filename for beta channel clients", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      headers: new Headers({
+        "Content-Type": "application/xml",
+      }),
+      ok: true,
+      text: async () => "<xml></xml>",
+    } as Response);
+
+    await mockAppcastBaseUrl("https://example.com/downloads/releases.xml");
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/v1/appcast/appcast-beta.xml?bundleIdentifier=com.example.app",
+      { method: "GET" },
+    );
+
+    await GET(request, { params: Promise.resolve({ path: ["appcast-beta.xml"] }) });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com/downloads/appcast-beta.xml",
+      expect.any(Object),
+    );
+  });
+
+  it("should preserve query parameters when replacing a direct stable filename", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      headers: new Headers({
+        "Content-Type": "application/xml",
+      }),
+      ok: true,
+      text: async () => "<xml></xml>",
+    } as Response);
+
+    await mockAppcastBaseUrl("https://example.com/downloads/releases.xml?token=abc");
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/v1/appcast/appcast-beta.xml?bundleIdentifier=com.example.app",
+      { method: "GET" },
+    );
+
+    await GET(request, { params: Promise.resolve({ path: ["appcast-beta.xml"] }) });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com/downloads/appcast-beta.xml?token=abc",
+      expect.any(Object),
+    );
+  });
+
+  it("should proxy a stable request to sibling stable XML when stored URL is a channel feed", async () => {
+    const upstream = await startLocalAppcastServer();
+    global.fetch = realFetch;
+
+    try {
+      await mockAppcastBaseUrl(`${upstream.origin}/updates/appcast-prerelease.xml`);
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/v1/appcast/appcast.xml?bundleIdentifier=com.example.app",
+        { method: "GET" },
+      );
+
+      const response = await GET(request, { params: Promise.resolve({ path: ["appcast.xml"] }) });
+
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("<stable></stable>");
+      expect(upstream.requests).toEqual(["/updates/appcast.xml"]);
+    } finally {
+      await upstream.close();
+    }
   });
 
   it("should parse app identification from User-Agent when no params provided", async () => {


### PR DESCRIPTION
## What

Fixes the appcast proxy channel crossing where a stable `/appcast.xml` request could receive a stored prerelease feed.

## Compatibility contract

- Direct `.xml` `appcast_base_url` values are treated as the canonical stable feed for default `/appcast.xml` clients, including custom stable names like `releases.xml`, unrecognized `appcast-enterprise.xml`, mixed-case names like `Appcast-Beta.xml`, and query/fragment suffixes.
- Only the exact lowercase known unstable basenames `appcast-prerelease.xml` and `appcast-beta.xml` are rewritten for stable `/appcast.xml` clients.
- When rewriting a direct XML filename, the proxy preserves query strings and fragments.
- Non-default proxy paths such as `/appcast-beta.xml` still replace the stored direct XML filename with the requested filename.

## Proof

Reproduced the `origin/main` crossing locally:

```json
{
  "stored": "https://example.com/updates/appcast-prerelease.xml",
  "requested": "appcast.xml",
  "upstreamFetchedOnMain": "https://example.com/updates/appcast-prerelease.xml"
}
```

Added route regressions covering custom stable XML, unrecognized `appcast-*`, mixed-case names, prerelease-to-stable, beta-to-stable, beta filename replacement, direct XML query/fragment preservation, existing direct folder/XML behavior, and a real local HTTP upstream proof. The local upstream proof drives the route with `global.fetch` restored to native fetch and records the actual upstream request as `/updates/appcast.xml` for a stable client whose stored URL is `/updates/appcast-prerelease.xml`.

## Local checks

- `pnpm test:api -- appcast` - 43 tests passed
- `pnpm lint` - passed
- `pnpm typecheck` - passed
- `pnpm test` - 234 tests passed
- `SKIP_ENV_VALIDATION=true pnpm build` - passed
- `pnpm test:coverage` - passed, 234 tests passed
- `autoreview --mode branch --base origin/main` - clean, no accepted/actionable findings

Thanks @devYRPauli for finding and starting the fix.
