### PR TITLE
fix(db): restore version adoption timeline

### DIFF
--- a/scripts/18-filter-unknown-values.sql
+++ b/scripts/18-filter-unknown-values.sql
@@ -226,17 +226,17 @@ AS $$
 BEGIN
     RETURN QUERY
     WITH top_versions AS (
-        SELECT app_version
-        FROM public.reports
+        SELECT top_report.app_version
+        FROM public.reports AS top_report
         WHERE 
-            (p_app_id_filter IS NULL OR app_id = p_app_id_filter) AND
-            received_at >= p_start_date_filter AND
-            received_at < (p_end_date_filter + INTERVAL '1 day') AND
-            app_version IS NOT NULL AND
-            app_version != '' AND
-            app_version != 'Unknown'
-        GROUP BY app_version
-        ORDER BY COUNT(DISTINCT ip_hash) DESC
+            (p_app_id_filter IS NULL OR top_report.app_id = p_app_id_filter) AND
+            top_report.received_at >= p_start_date_filter AND
+            top_report.received_at < (p_end_date_filter + INTERVAL '1 day') AND
+            top_report.app_version IS NOT NULL AND
+            top_report.app_version != '' AND
+            top_report.app_version != 'Unknown'
+        GROUP BY top_report.app_version
+        ORDER BY COUNT(DISTINCT top_report.ip_hash) DESC
         LIMIT p_top_versions
     )
     SELECT
@@ -249,12 +249,12 @@ BEGIN
         (p_app_id_filter IS NULL OR r.app_id = p_app_id_filter) AND
         r.received_at >= p_start_date_filter AND
         r.received_at < (p_end_date_filter + INTERVAL '1 day') AND
-        r.app_version IN (SELECT app_version FROM top_versions)
+        r.app_version IN (SELECT top_versions.app_version FROM top_versions)
     GROUP BY
         DATE(r.received_at),
         r.app_version
     ORDER BY
-        report_date,
+        DATE(r.received_at),
         r.app_version;
 END;
 $$;

--- a/supabase/migrations/20260706081359_fix_version_adoption_timeline.sql
+++ b/supabase/migrations/20260706081359_fix_version_adoption_timeline.sql
@@ -1,0 +1,46 @@
+-- PL/pgSQL output columns are variables. Qualify app_version throughout the
+-- query so it cannot conflict with the function's app_version output column.
+CREATE OR REPLACE FUNCTION public.get_version_adoption_timeline(
+    p_app_id_filter UUID DEFAULT NULL,
+    p_start_date_filter TIMESTAMPTZ DEFAULT (NOW() - INTERVAL '29 days'),
+    p_end_date_filter TIMESTAMPTZ DEFAULT NOW(),
+    p_top_versions INT DEFAULT 5
+)
+RETURNS TABLE (report_date DATE, app_version TEXT, user_count BIGINT)
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+    RETURN QUERY
+    WITH top_versions AS (
+        SELECT top_report.app_version
+        FROM public.reports AS top_report
+        WHERE
+            (p_app_id_filter IS NULL OR top_report.app_id = p_app_id_filter) AND
+            top_report.received_at >= p_start_date_filter AND
+            top_report.received_at < (p_end_date_filter + INTERVAL '1 day') AND
+            top_report.app_version IS NOT NULL AND
+            top_report.app_version != '' AND
+            top_report.app_version != 'Unknown'
+        GROUP BY top_report.app_version
+        ORDER BY COUNT(DISTINCT top_report.ip_hash) DESC
+        LIMIT p_top_versions
+    )
+    SELECT
+        DATE(report.received_at) AS report_date,
+        report.app_version,
+        COUNT(DISTINCT report.ip_hash) AS user_count
+    FROM public.reports AS report
+    WHERE
+        (p_app_id_filter IS NULL OR report.app_id = p_app_id_filter) AND
+        report.received_at >= p_start_date_filter AND
+        report.received_at < (p_end_date_filter + INTERVAL '1 day') AND
+        report.app_version IN (SELECT top_versions.app_version FROM top_versions)
+    GROUP BY
+        DATE(report.received_at),
+        report.app_version
+    ORDER BY
+        DATE(report.received_at),
+        report.app_version;
+END;
+$$;


### PR DESCRIPTION
## Summary

- replace the broken production `get_version_adoption_timeline` function with a qualified `app_version` query
- add the repair as a Supabase migration
- repair the canonical legacy SQL definition too

## Root cause

The live RPC failed with PostgreSQL `42703` because its deployed function referenced nonexistent `r.version`. The repository definition also failed independently because unqualified `app_version` conflicted with the PL/pgSQL output column.

## Verification

- reproduced the live production RPC failure through the public Supabase client path
- reproduced the repository function failure on PostgreSQL 14: `column reference "app_version" is ambiguous`
- applied the migration to PostgreSQL 14 and verified app filtering, top-version limiting, unique-user counts, and `Unknown` exclusion
- production rollback rehearsal: migration applied, RPC returned 116 rows, transaction rolled back
- production migration applied atomically and recorded as `20260706081359`
- live production RPC: 200, 116 rows, expected three-field shape, zero invalid rows
- live production dashboard: 200, Version Adoption Timeline present, prior error absent
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (28 files, 234 tests)
- `pnpm build`
- `pnpm audit --prod --audit-level high`
- structured autoreview: clean, no actionable findings (0.98 confidence)
