### PR TITLE
docs: fix Supabase bootstrap order

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ pnpm install
 cp .env.example .env.local
 # Edit .env.local with your Supabase credentials
 
-# Run database migrations (Supabase)
-# (requires Supabase CLI + DB password/connection string; see docs/deployment.md)
+# Bootstrap a new Supabase project by running every present scripts/*.sql file
+# in numeric order in the SQL Editor. Then apply managed migrations:
 supabase link --project-ref <your_project_ref>
 supabase db push
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,6 +17,10 @@ This guide will help you deploy your own instance of stats.store.
    - Select a region close to your users
 
 2. **Run the database migrations**
+   - In the Supabase dashboard, open the SQL Editor
+   - Run every present numbered file in `scripts/` in numeric order
+     - Start with `01-create-apps-table.sql` and finish with `18-filter-unknown-values.sql`
+     - Gaps in the numbering are intentional
    - Install Supabase CLI (`supabase --version`)
    - Copy `.env.migrations.example` → `.env.migrations` and fill it in
    - Run:
@@ -25,7 +29,7 @@ This guide will help you deploy your own instance of stats.store.
      supabase link --project-ref "$SUPABASE_PROJECT_REF"
      supabase db push --password "$SUPABASE_DB_PASSWORD"
      \`\`\`
-   - This applies `supabase/migrations/*` to your remote database
+   - This applies the managed real-time infrastructure and later fixes from `supabase/migrations/*`
 
 3. **Enable real-time (optional but cool!)**
    - Go to Database → Replication

--- a/docs/realtime-setup.md
+++ b/docs/realtime-setup.md
@@ -31,7 +31,7 @@ The real-time system uses an aggregated update approach (Option 2) that provides
 
 ### 1. Run Database Migrations
 
-Apply the Supabase migration:
+Complete the [base database setup](deployment.md#step-1-set-up-supabase), then apply the managed Supabase migrations:
 
 \`\`\`bash
 


### PR DESCRIPTION
## Summary

- document the required numbered SQL bootstrap for new Supabase projects
- keep `supabase db push` as the second step for managed real-time migrations and later fixes
- link the realtime guide back to the base database setup

## Verification

- reproduced the documented old path on fresh PostgreSQL: the first managed migration fails because `public.apps` does not exist
- ran every present `scripts/*.sql` file in numeric order, then every `supabase/migrations/*.sql` file, on fresh PostgreSQL 14
- verified the resulting `apps` and `reports` tables and `get_version_adoption_timeline` RPC
- `pnpm format:check`

Docs-only change; structured code review skipped.
