### PR TITLE
docs: render setup code blocks

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -24,11 +24,11 @@ This guide will help you deploy your own instance of stats.store.
    - Install Supabase CLI (`supabase --version`)
    - Copy `.env.migrations.example` → `.env.migrations` and fill it in
    - Run:
-     \`\`\`bash
+     ```bash
      set -a; source .env.migrations; set +a
      supabase link --project-ref "$SUPABASE_PROJECT_REF"
      supabase db push --password "$SUPABASE_DB_PASSWORD"
-     \`\`\`
+     ```
    - This applies the managed real-time infrastructure and later fixes from `supabase/migrations/*`
 
 3. **Enable real-time (optional but cool!)**
@@ -55,26 +55,27 @@ Click the button and fill in your Supabase credentials!
 ### Option B: Manual Deploy
 
 1. **Fork the repository**
-   \`\`\`bash
+
+   ```bash
 
    # On GitHub, click "Fork" button
 
    # Then clone your fork:
 
    git clone https://github.com/YOUR_USERNAME/stats-store.git
-   \`\`\`
+   ```
 
 2. **Import to Vercel**
    - Go to [vercel.com/new](https://vercel.com/new)
    - Import your forked repository
    - Configure environment variables:
-     \`\`\`
+     ```
      SUPABASE_URL=your_supabase_url
      SUPABASE_ANON_KEY=your_anon_key
      SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
      NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
      NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key
-     \`\`\`
+     ```
      Alternatively, in Vercel UI, set:
      - `SUPABASE_URL`
      - `SUPABASE_ANON_KEY`
@@ -92,11 +93,12 @@ Click the button and fill in your Supabase credentials!
 1. **Go to your Supabase dashboard**
 2. **Navigate to Table Editor → apps**
 3. **Insert a new row:**
-   \`\`\`
+
+   ```
    name: Your App Name
    bundle_identifier: com.yourcompany.yourapp
    appcast_base_url: https://github.com/you/yourapp
-   \`\`\`
+   ```
 
 4. **Update your app's Sparkle URL** (see README)
 
@@ -131,12 +133,13 @@ Want to use your own domain instead of `*.vercel.app`?
 When new features are released:
 
 1. **Sync your fork** (if you forked)
-   \`\`\`bash
+
+   ```bash
    git remote add upstream https://github.com/steipete/stats-store.git
    git fetch upstream
    git merge upstream/main
    git push origin main
-   \`\`\`
+   ```
 
 2. **Run new migrations** (if any)
    - Run `supabase db push` again

--- a/docs/realtime-setup.md
+++ b/docs/realtime-setup.md
@@ -33,22 +33,22 @@ The real-time system uses an aggregated update approach (Option 2) that provides
 
 Complete the [base database setup](deployment.md#step-1-set-up-supabase), then apply the managed Supabase migrations:
 
-\`\`\`bash
+```bash
 
 # Recommended (CLI)
 
 supabase link --project-ref <your_project_ref>
 supabase db push
-\`\`\`
+```
 
 ### 2. Configure Environment Variables
 
 Ensure your `.env.local` includes the public Supabase keys:
 
-\`\`\`env
+```env
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key
-\`\`\`
+```
 
 ### 3. Enable Realtime in Supabase
 
@@ -111,34 +111,34 @@ Updates are batched to balance real-time feel with performance:
 
 In `supabase/migrations/20251227125800_realtime_tables_and_triggers.sql`, modify:
 
-\`\`\`sql
+```sql
 -- Change batch size (default: 10)
 IF v_pending_count >= 10 OR
 
 -- Change time interval (default: 30 seconds)
 v_last_aggregation < now() - INTERVAL '30 seconds' THEN
-\`\`\`
+```
 
 ### Add Custom Milestones
 
 Edit the milestones array in the trigger:
 
-\`\`\`sql
+```sql
 v_milestones INT[] := ARRAY[10, 50, 100, 500, 1000, 5000, 10000];
-\`\`\`
+```
 
 ### Customize Notifications
 
 Modify toast notifications in `components/realtime-dashboard-wrapper.tsx`:
 
-\`\`\`typescript
+```typescript
 onNewUser: (event) => {
 toast.success(`New user detected!`, {
 description: `App version: ${event.event_data.app_version}`,
 icon: <SparklesIcon className="h-4 w-4" />,
 })
 }
-\`\`\`
+```
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- unescape fenced code blocks in the deployment guide
- unescape fenced code blocks in the real-time setup guide
- let the formatter restore valid list/code-block spacing

## Verification

- GitHub Markdown rendering before: zero code blocks and literal triple-backtick text
- GitHub Markdown rendering after: five code blocks in each guide and zero literal fence markers
- `pnpm format:check`

Docs-only change; structured code review skipped.
