### PR TITLE
docs: render reference code blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,23 +24,25 @@ Thanks for your interest in contributing! 🎉
 Awesome! Here's how:
 
 1. **Fork & Clone**
-   \`\`\`bash
+
+   ```bash
 
    # Fork on GitHub first, then:
 
    git clone https://github.com/YOUR_USERNAME/stats-store.git
    cd stats-store
    pnpm install
-   \`\`\`
+   ```
 
 2. **Create a Branch**
-   \`\`\`bash
+
+   ```bash
    git checkout -b fix/awesome-bug-fix
 
    # or
 
    git checkout -b feature/cool-new-thing
-   \`\`\`
+   ```
 
 3. **Make Your Changes**
    - Write clean, readable code
@@ -48,22 +50,24 @@ Awesome! Here's how:
    - Add tests if needed
 
 4. **Test Everything**
-   \`\`\`bash
+
+   ```bash
    pnpm test # Run tests
    pnpm lint # Check linting
    pnpm typecheck # TypeScript checks
    pnpm build # Make sure it builds
-   \`\`\`
+   ```
 
 5. **Commit Your Changes**
-   \`\`\`bash
+
+   ```bash
    git add .
    git commit -m "fix: solve the awesome bug"
 
    # or
 
    git commit -m "feat: add cool new thing"
-   \`\`\`
+   ```
 
    We use [conventional commits](https://www.conventionalcommits.org/):
    - `fix:` for bug fixes
@@ -73,9 +77,9 @@ Awesome! Here's how:
    - `refactor:` for code refactoring
 
 6. **Push and Create PR**
-   \`\`\`bash
+   ```bash
    git push origin your-branch-name
-   \`\`\`
+   ```
    Then open a Pull Request on GitHub!
 
 ## Development Setup
@@ -94,14 +98,14 @@ Awesome! Here's how:
 
 ### Useful Commands
 
-\`\`\`bash
+```bash
 pnpm dev # Start dev server
 pnpm test # Run tests
 pnpm test:watch # Run tests in watch mode
 pnpm lint # Run linter
 pnpm format # Format code
 pnpm build # Build for production
-\`\`\`
+```
 
 ## Code Style
 

--- a/docs/APPCAST_PROXY.md
+++ b/docs/APPCAST_PROXY.md
@@ -15,25 +15,25 @@ Stats Store can act as a proxy for your Sparkle appcast feeds, allowing you to c
 
 ### 1. Add your appcast URL to the database
 
-\`\`\`sql
+```sql
 UPDATE apps
 SET appcast_base_url = 'https://github.com/yourname/yourrepo'
 WHERE bundle_identifier = 'com.yourcompany.yourapp';
-\`\`\`
+```
 
 ### 2. Update your Sparkle configuration
 
 Instead of pointing to your actual appcast URL, use:
 
-\`\`\`
+```
 https://stats.store/api/v1/appcast/appcast.xml
-\`\`\`
+```
 
 For prerelease/beta channels:
 
-\`\`\`
+```
 https://stats.store/api/v1/appcast/appcast-prerelease.xml
-\`\`\`
+```
 
 ## URL Patterns
 
@@ -76,9 +76,9 @@ The proxy intelligently handles cases where:
 
 Use the provided test script:
 
-\`\`\`bash
+```bash
 ./test-appcast-proxy.sh
-\`\`\`
+```
 
 ## Example Sparkle Requests
 
@@ -86,19 +86,19 @@ Use the provided test script:
 
 When Sparkle sends system profile data, the request includes query parameters:
 
-\`\`\`
+```
 GET /api/v1/appcast/appcast.xml?appName=MyApp&appVersion=123&osVersion=14.0&cputype=16777228&model=MacBookPro17,1&ncpu=8&lang=en&ramMB=16384
 User-Agent: MyApp/2.1.3 Sparkle/2.0.0
-\`\`\`
+```
 
 ### Without System Profiling (most requests)
 
 Most requests come without query parameters due to privacy throttling:
 
-\`\`\`
+```
 GET /api/v1/appcast/appcast.xml
 User-Agent: MyApp/2.1.3 Sparkle/2.0.0
-\`\`\`
+```
 
 **Important:** The proxy now intelligently handles both cases:
 

--- a/docs/SPARKLE_INTEGRATION.md
+++ b/docs/SPARKLE_INTEGRATION.md
@@ -4,26 +4,26 @@ This stats-store application provides an API endpoint to collect update statisti
 
 ## API Endpoint
 
-\`\`\`
+```
 POST https://stats.store/api/v1/ingest
-\`\`\`
+```
 
 ## Request Format
 
 The endpoint expects a JSON payload with the following structure:
 
-\`\`\`json
+```json
 {
-"bundleIdentifier": "com.company.appname", // Required
-"appVersion": "2.1.0", // Optional
-"osVersion": "14.2", // Optional
-"cputype": "16777228", // Optional (16777228 = arm64, 16777223 = x86_64)
-"ncpu": "8", // Optional
-"lang": "en", // Optional
-"model": "MacBookPro18,3", // Optional
-"ramMB": "16384" // Optional
+  "bundleIdentifier": "com.company.appname", // Required
+  "appVersion": "2.1.0", // Optional
+  "osVersion": "14.2", // Optional
+  "cputype": "16777228", // Optional (16777228 = arm64, 16777223 = x86_64)
+  "ncpu": "8", // Optional
+  "lang": "en", // Optional
+  "model": "MacBookPro18,3", // Optional
+  "ramMB": "16384" // Optional
 }
-\`\`\`
+```
 
 ## Setting Up Your App
 
@@ -46,7 +46,7 @@ The endpoint expects a JSON payload with the following structure:
 
 For a custom Sparkle delegate implementation:
 
-\`\`\`swift
+```swift
 func updater(\_ updater: SPUUpdater, willCheckForUpdates: SPUUpdateCheck) {
 // Send stats to stats.store
 let statsURL = URL(string: "https://stats.store/api/v1/ingest")!
@@ -66,13 +66,13 @@ request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     URLSession.shared.dataTask(with: request).resume()
 
 }
-\`\`\`
+```
 
 ## Testing
 
 You can test the endpoint with curl:
 
-\`\`\`bash
+```bash
 curl -X POST https://stats.store/api/v1/ingest \
  -H "Content-Type: application/json" \
  -d '{
@@ -80,7 +80,7 @@ curl -X POST https://stats.store/api/v1/ingest \
 "appVersion": "1.0.0",
 "osVersion": "14.2"
 }'
-\`\`\`
+```
 
 ## Data Collected
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,14 +15,14 @@ stats.store is built on a modern serverless architecture:
 
 ### Appcast Proxy Flow (Primary Method)
 
-\`\`\`mermaid
+```mermaid
 graph LR
 A[Mac App] -->|Update Check| B[stats.store/api/v1/appcast]
 B -->|1. Log Stats| C[Supabase DB]
 B -->|2. Fetch| D[Original Appcast URL]
 D -->|3. Return| B
 B -->|4. Serve| A
-\`\`\`
+```
 
 1. **App checks for updates**: Sparkle sends a request to stats.store instead of the original URL
 2. **stats.store logs the request**: Extracts system info from Sparkle's query parameters
@@ -33,11 +33,11 @@ B -->|4. Serve| A
 
 For apps that want more control, there's also a direct API endpoint:
 
-\`\`\`mermaid
+```mermaid
 graph LR
 A[Mac App] -->|POST| B[stats.store/api/v1/ingest]
 B -->|Validate & Store| C[Supabase DB]
-\`\`\`
+```
 
 ## Database Schema
 
@@ -47,7 +47,7 @@ B -->|Validate & Store| C[Supabase DB]
 
 Stores registered applications:
 
-\`\`\`sql
+```sql
 CREATE TABLE public.apps (
 id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 name TEXT NOT NULL UNIQUE,
@@ -55,13 +55,13 @@ bundle_identifier TEXT NOT NULL UNIQUE,
 appcast_base_url TEXT, -- GitHub URL for appcast proxy
 created_at TIMESTAMPTZ DEFAULT now()
 );
-\`\`\`
+```
 
 #### `reports` Table
 
 Stores sanitized telemetry data:
 
-\`\`\`sql
+```sql
 CREATE TABLE public.reports (
 id BIGSERIAL PRIMARY KEY,
 app_id UUID NOT NULL REFERENCES public.apps(id) ON DELETE CASCADE,
@@ -75,7 +75,7 @@ language TEXT,
 model_identifier TEXT, -- e.g., "MacBookPro17,1"
 ram_mb INT
 );
-\`\`\`
+```
 
 ### Real-Time Tables (New)
 
@@ -83,7 +83,7 @@ ram_mb INT
 
 Pre-computed aggregates for real-time performance:
 
-\`\`\`sql
+```sql
 CREATE TABLE public.stats_cache (
 id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 app_id UUID REFERENCES public.apps(id) ON DELETE CASCADE,
@@ -93,13 +93,13 @@ period_start TIMESTAMPTZ,
 period_end TIMESTAMPTZ,
 updated_at TIMESTAMPTZ DEFAULT now()
 );
-\`\`\`
+```
 
 #### `realtime_events` Table
 
 Tracks events for live updates:
 
-\`\`\`sql
+```sql
 CREATE TABLE public.realtime_events (
 id BIGSERIAL PRIMARY KEY,
 app_id UUID REFERENCES public.apps(id) ON DELETE CASCADE,
@@ -107,7 +107,7 @@ event_type TEXT NOT NULL, -- 'new_user', 'milestone', etc.
 event_data JSONB NOT NULL,
 created_at TIMESTAMPTZ DEFAULT now()
 );
-\`\`\`
+```
 
 ## API Documentation
 
@@ -116,18 +116,19 @@ created_at TIMESTAMPTZ DEFAULT now()
 Direct telemetry endpoint for apps that want to send data explicitly.
 
 **Request:**
-\`\`\`json
+
+```json
 {
-"bundleIdentifier": "com.example.app",
-"appVersion": "1.0.0",
-"osVersion": "14.0",
-"cputype": "16777228", // Sparkle CPU type code
-"ncpu": "8",
-"lang": "en",
-"model": "MacBookPro17,1",
-"ramMB": "16384"
+  "bundleIdentifier": "com.example.app",
+  "appVersion": "1.0.0",
+  "osVersion": "14.0",
+  "cputype": "16777228", // Sparkle CPU type code
+  "ncpu": "8",
+  "lang": "en",
+  "model": "MacBookPro17,1",
+  "ramMB": "16384"
 }
-\`\`\`
+```
 
 **Response:**
 
@@ -140,9 +141,10 @@ Direct telemetry endpoint for apps that want to send data explicitly.
 Appcast proxy endpoint. This is where the magic happens!
 
 **URL Structure:**
-\`\`\`
+
+```
 https://stats.store/api/v1/appcast/appcast.xml?[sparkle-parameters]
-\`\`\`
+```
 
 **Sparkle Parameters (automatically sent by Sparkle):**
 
@@ -166,10 +168,11 @@ https://stats.store/api/v1/appcast/appcast.xml?[sparkle-parameters]
 5. **Fetch and return** the original appcast
 
 **Example Flow:**
-\`\`\`
+
+```
 App requests: https://stats.store/api/v1/appcast/appcast.xml?bundleIdentifier=com.example.app
 We fetch: https://raw.githubusercontent.com/example/app/main/appcast.xml
-\`\`\`
+```
 
 ## Privacy & Security Implementation
 
@@ -177,10 +180,10 @@ We fetch: https://raw.githubusercontent.com/example/app/main/appcast.xml
 
 IPs are never stored. Instead:
 
-\`\`\`typescript
-const dailySalt = format(new Date(), 'yyyy-MM-dd')
-const ipHash = sha256(ip + dailySalt)
-\`\`\`
+```typescript
+const dailySalt = format(new Date(), "yyyy-MM-dd");
+const ipHash = sha256(ip + dailySalt);
+```
 
 This means:
 
@@ -203,41 +206,45 @@ All incoming data is validated and sanitized:
 
 Database triggers automatically update aggregates:
 
-\`\`\`sql
+```sql
 -- After new report insert:
 -- 1. Check if new unique user
 -- 2. Update stats cache if needed
 -- 3. Emit real-time events
 -- 4. Check for milestones
-\`\`\`
+```
 
 ### WebSocket Subscriptions
 
 Clients subscribe to changes via Supabase Realtime:
 
-\`\`\`typescript
+```typescript
 supabase
-.channel('app-stats')
-.on('postgres_changes', {
-event: 'INSERT',
-schema: 'public',
-table: 'realtime_events'
-}, handleRealtimeUpdate)
-.subscribe()
-\`\`\`
+  .channel("app-stats")
+  .on(
+    "postgres_changes",
+    {
+      event: "INSERT",
+      schema: "public",
+      table: "realtime_events",
+    },
+    handleRealtimeUpdate,
+  )
+  .subscribe();
+```
 
 ## Performance Optimizations
 
 ### Database Indexes
 
-\`\`\`sql
+```sql
 CREATE INDEX idx_reports_app_id_received_at
 ON public.reports(app_id, received_at DESC);
 CREATE INDEX idx_reports_os_version
 ON public.reports(os_version);
 CREATE INDEX idx_reports_cpu_arch
 ON public.reports(cpu_arch);
-\`\`\`
+```
 
 ### Caching Strategy
 
@@ -249,7 +256,7 @@ ON public.reports(cpu_arch);
 
 ### Project Structure
 
-\`\`\`
+```
 stats-store/
 ├── app/ # Next.js App Router
 │ ├── api/v1/ # API endpoints
@@ -257,17 +264,17 @@ stats-store/
 │ │ └── appcast/ # Proxy endpoint
 │ ├── page.tsx # Dashboard (server component)
 │ └── globals.css # Tailwind styles
-├── components/  
+├── components/
 │ ├── ui/ # shadcn/ui components
 │ ├── client-_.tsx # Client-side charts
 │ └── realtime-_.tsx # Real-time components
 ├── hooks/ # Custom React hooks
-├── lib/  
+├── lib/
 │ ├── supabase/ # Database client
 │ └── utils.ts # Helpers
 ├── scripts/ # SQL migrations
 └── tests/ # Vitest tests
-\`\`\`
+```
 
 ### Testing Strategy
 
@@ -280,7 +287,7 @@ stats-store/
 
 ### Environment Variables
 
-\`\`\`env
+```env
 
 # Required for all environments
 
@@ -292,7 +299,7 @@ SUPABASE_SERVICE_ROLE_KEY=[service-key]
 
 NEXT_PUBLIC_SUPABASE_URL=https://[project].supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=[anon-key]
-\`\`\`
+```
 
 ### Vercel Configuration
 
@@ -316,23 +323,25 @@ Run scripts in order:
 ### Useful Queries
 
 **Daily active users:**
-\`\`\`sql
+
+```sql
 SELECT DATE(received_at) as day, COUNT(DISTINCT ip_hash) as users
 FROM reports
 WHERE app_id = '[app-id]'
 GROUP BY day
 ORDER BY day DESC;
-\`\`\`
+```
 
 **Version adoption:**
-\`\`\`sql
+
+```sql
 SELECT app_version, COUNT(DISTINCT ip_hash) as users
 FROM reports
 WHERE app_id = '[app-id]'
 AND received_at > NOW() - INTERVAL '30 days'
 GROUP BY app_version
 ORDER BY users DESC;
-\`\`\`
+```
 
 ### Common Issues
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -48,7 +48,7 @@ The data will be stored in a Supabase PostgreSQL database. The schema is designe
 
 Stores information about each tracked application. An application must be registered here to have its reports accepted.
 
-\`\`\`sql
+```sql
 -- Stores metadata for each application being tracked.
 CREATE TABLE public.apps (
 -- A unique identifier for the app.
@@ -67,13 +67,13 @@ created_at TIMESTAMPTZ DEFAULT now()
 
 -- Enable Row Level Security to control data access.
 ALTER TABLE public.apps ENABLE ROW LEVEL SECURITY;
-\`\`\`
+```
 
 #### 3.2. Table: `reports`
 
 Stores sanitized data from each individual Sparkle profile report.
 
-\`\`\`sql
+```sql
 -- Stores every individual, sanitized profile report received.
 CREATE TABLE public.reports (
 -- A unique, auto-incrementing identifier for each report.
@@ -118,7 +118,7 @@ CREATE INDEX idx_reports_cpu_arch ON public.reports(cpu_arch);
 
 -- Enable Row Level Security.
 ALTER TABLE public.reports ENABLE ROW LEVEL SECURITY;
-\`\`\`
+```
 
 ### 4. API Design (Next.js API Routes)
 
@@ -129,19 +129,19 @@ The API is implemented as **Next.js API Routes**, keeping all code within a sing
 - **Purpose:** The public endpoint to receive new profile data from Sparkle clients.
 - **Security:** This endpoint is open but validates incoming data. It checks that the `bundle_identifier` in the payload matches an application pre-registered in the `apps` table. This prevents data from unknown applications from being stored. It is a deliberate design choice to accept that a malicious actor could send fake data for a known application.
 - **Request Body:**
-  \`\`\`json
+  ```json
   {
-  "bundleIdentifier": "com.mycompany.myawesomeapp",
-  "ip": "123.45.67.89",
-  "appVersion": "1.2.3",
-  "osVersion": "14.5",
-  "cputype": "16777228",
-  "ncpu": "8",
-  "lang": "en",
-  "model": "MacBookPro17,1",
-  "ramMB": "16384"
+    "bundleIdentifier": "com.mycompany.myawesomeapp",
+    "ip": "123.45.67.89",
+    "appVersion": "1.2.3",
+    "osVersion": "14.5",
+    "cputype": "16777228",
+    "ncpu": "8",
+    "lang": "en",
+    "model": "MacBookPro17,1",
+    "ramMB": "16384"
   }
-  \`\`\`
+  ```
 - **Action:**
   1.  The API route receives the JSON payload.
   2.  It extracts the `bundleIdentifier`.
@@ -158,27 +158,27 @@ The API is implemented as **Next.js API Routes**, keeping all code within a sing
   - Filter by `app_id` (optional, UUID).
   - Filter by `start_date` and `end_date` (optional, ISO 8601).
 - **Response Payload (Passed as props to the dashboard component):**
-  \`\`\`json
+  ```json
   {
-  "kpis": {
-  "unique_installs": 12543,
-  "reports_this_period": 876,
-  "latest_version": "1.2.3"
-  },
-  "installs_timeseries": [
-  { "date": "2025-06-10", "count": 150 },
-  { "date": "2025-06-11", "count": 165 }
-  ],
-  "os_breakdown": [
-  { "name": "macOS 14 Sonoma", "value": 6012 },
-  { "name": "macOS 13 Ventura", "value": 4531 }
-  ],
-  "cpu_breakdown": [
-  { "name": "Apple Silicon", "value": 9876 },
-  { "name": "Intel", "value": 2667 }
-  ]
+    "kpis": {
+      "unique_installs": 12543,
+      "reports_this_period": 876,
+      "latest_version": "1.2.3"
+    },
+    "installs_timeseries": [
+      { "date": "2025-06-10", "count": 150 },
+      { "date": "2025-06-11", "count": 165 }
+    ],
+    "os_breakdown": [
+      { "name": "macOS 14 Sonoma", "value": 6012 },
+      { "name": "macOS 13 Ventura", "value": 4531 }
+    ],
+    "cpu_breakdown": [
+      { "name": "Apple Silicon", "value": 9876 },
+      { "name": "Intel", "value": 2667 }
+    ]
   }
-  \`\`\`
+  ```
 
 ### 5. Frontend Design (UI/UX)
 
@@ -186,7 +186,7 @@ The dashboard will be clean, modern, and data-focused, using a dark theme with v
 
 #### 5.1. Dashboard Wireframe & Layout
 
-\`\`\`
+```
 /-------------------------------------------------------------------------------------\
 | [App Stats Store] [User: dev@email] |
 |-------------------------------------------------------------------------------------|
@@ -220,7 +220,7 @@ The dashboard will be clean, modern, and data-focused, using a dark theme with v
 | \---------------------------/ \-----------------------------------------------/ |
 | |
 \-------------------------------------------------------------------------------------/
-\`\`\`
+```
 
 #### 5.2. Key UI Components and Technology Choices
 

--- a/docs/tooltip-implementation.md
+++ b/docs/tooltip-implementation.md
@@ -31,7 +31,7 @@ The KpiCard component is now used in `app/page.tsx` with the following tooltip t
 
 ### Usage Example:
 
-\`\`\`tsx
+```tsx
 <KpiCard
   title="Unique Users"
   value={valueFormatter(data.kpis.unique_installs)}
@@ -39,7 +39,7 @@ The KpiCard component is now used in `app/page.tsx` with the following tooltip t
   iconColor="blue"
   tooltip="Unique users (based on IP hash) from Jan 1 to Jan 31"
 />
-\`\`\`
+```
 
 ## Solution 2: Native HTML Title Attribute (Simple Alternative)
 
@@ -65,7 +65,7 @@ For a simpler approach without client-side JavaScript, we also created `KpiCardS
 
 ### Usage Example:
 
-\`\`\`tsx
+```tsx
 <KpiCardSimple
   title="Unique Users"
   value={valueFormatter(data.kpis.unique_installs)}
@@ -73,7 +73,7 @@ For a simpler approach without client-side JavaScript, we also created `KpiCardS
   iconColor="blue"
   tooltip="Unique users (based on IP hash) from Jan 1 to Jan 31"
 />
-\`\`\`
+```
 
 ## Current Implementation
 
@@ -88,13 +88,13 @@ The dashboard currently uses Solution 1 (Radix UI) as it provides a better user 
 
 To switch to the simpler solution, replace the import in `app/page.tsx`:
 
-\`\`\`tsx
+```tsx
 // Replace this:
-import { KpiCard } from "@/components/kpi-card"
+import { KpiCard } from "@/components/kpi-card";
 
 // With this:
-import { KpiCardSimple as KpiCard } from "@/components/kpi-card-simple"
-\`\`\`
+import { KpiCardSimple as KpiCard } from "@/components/kpi-card-simple";
+```
 
 ## Styling Customization
 


### PR DESCRIPTION
## Summary

- unescape fenced code blocks across the contributor and reference guides
- format the newly recognized SQL, JSON, TypeScript, Swift, Mermaid, shell, and text blocks
- leave agent-only `CLAUDE.md` outside this public-doc cleanup

## Verification

- confirmed the defect with GitHub's GFM renderer before the API throttle: these files rendered literal triple-backtick text instead of code blocks
- Pandoc GFM rendering after: 41 code blocks across six files, zero literal fence markers
- `pnpm format:check`

Docs-only change; structured code review skipped.
